### PR TITLE
Convert tests to typescript

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,21 +8,21 @@
   },
   "repository": "https://github.com/guardian/pkgu.git",
   "license": "MIT",
-  "main": "dist/cjs/index.js",
-  "module": "dist/esm/index.js",
-  "types": "dist/types/index.d.ts",
+  "main": "dist/cjs/src/index.js",
+  "module": "dist/esm/src/index.js",
+  "types": "dist/types/src/index.d.ts",
   "bin": {
-    "pkgu": "dist/cjs/index.js"
+    "pkgu": "dist/cjs/src/index.js"
   },
   "files": [
     "dist"
   ],
   "scripts": {
     "prebuild": "rm -rf dist",
-    "build": "ts-node --compiler-options='{\"module\":\"commonJS\"}' src/index.ts build",
+    "build": "ts-node src/index.ts build",
     "lint": "eslint .",
     "release": "np",
-    "test": "node script/test.js"
+    "test": "ts-node script/test.ts"
   },
   "prettier": "@guardian/prettier",
   "dependencies": {

--- a/script/test.ts
+++ b/script/test.ts
@@ -1,6 +1,6 @@
-const chalk = require('chalk');
-const execa = require('execa');
-const Listr = require('listr');
+import chalk from 'chalk';
+import execa from 'execa';
+import Listr from 'listr';
 
 const tasks = new Listr([
 	{
@@ -31,6 +31,10 @@ const tasks = new Listr([
 	},
 ]);
 
+interface BuildError {
+	stdout: string;
+}
+
 tasks
 	.run()
 	.then(() =>
@@ -40,11 +44,11 @@ tasks
 			),
 		),
 	)
-	.catch((e) => {
+	.catch((e: BuildError) => {
 		console.log(
 			chalk.red(
 				'The builds are not identical. The project does not build itself correctly.',
 			),
-		),
-			console.log(e.stdout);
+		);
+		console.log(e.stdout);
 	});

--- a/src/verify-package-json.ts
+++ b/src/verify-package-json.ts
@@ -16,9 +16,9 @@ export const verifyPackageJson = () => {
 		);
 	}
 
-	pkg.main = 'dist/cjs/index.js';
-	pkg.module = 'dist/esm/index.js';
-	pkg.types = 'dist/types/index.d.ts';
+	pkg.main = 'dist/cjs/src/index.js';
+	pkg.module = 'dist/esm/src/index.js';
+	pkg.types = 'dist/types/src/index.d.ts';
 	pkg.files = ['dist', ...(pkg.files ?? [])];
 
 	// @ts-expect-error -- shouldn't be there

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -6,10 +6,10 @@
     "module": "ESNext",
     "moduleResolution": "node",
     "noEmit": true,
-    "rootDir": "src",
     "strict": true,
     "target": "ES2020"
   },
-  "include": ["src"],
-  "exclude": ["node_modules", "dist", "coverage"]
+  "include": ["src", "script"],
+  "exclude": ["node_modules", "dist", "coverage"],
+  "ts-node": { "compilerOptions": { "module": "commonjs" } }
 }


### PR DESCRIPTION
## What does this change?

Converts the test script to TypeScript, and executes it via ts-node

## How to test

```sh
$ yarn test
$ yarn lint
```

## How can we measure success?

This eliminates a strange linting error that @jamie-lynch identified many moons ago in #25. Presumably there was some weirdness at the intersection of this file, ESLint and its TypeScript parser. Ensuring all code is in TypeScript reduces the complexity of this project while improving its type safety.

