### PR TITLE
revert #39

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -1,5 +1,9 @@
 {
 	"extends": "@guardian/eslint-config",
+	"parserOptions": {
+		"ecmaVersion": 2020
+	},
+
 	"ignorePatterns": ["dist"],
 	"overrides": [
 		{

--- a/package.json
+++ b/package.json
@@ -8,21 +8,21 @@
   },
   "repository": "https://github.com/guardian/pkgu.git",
   "license": "MIT",
-  "main": "dist/cjs/src/index.js",
-  "module": "dist/esm/src/index.js",
-  "types": "dist/types/src/index.d.ts",
+  "main": "dist/cjs/index.js",
+  "module": "dist/esm/index.js",
+  "types": "dist/types/index.d.ts",
   "bin": {
-    "pkgu": "dist/cjs/src/index.js"
+    "pkgu": "dist/cjs/index.js"
   },
   "files": [
     "dist"
   ],
   "scripts": {
     "prebuild": "rm -rf dist",
-    "build": "ts-node src/index.ts build",
+    "build": "ts-node --compiler-options='{\"module\":\"commonJS\"}' src/index.ts build",
     "lint": "eslint .",
     "release": "np",
-    "test": "ts-node script/test.ts"
+    "test": "node script/test.js"
   },
   "prettier": "@guardian/prettier",
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
   ],
   "scripts": {
     "prebuild": "rm -rf dist",
-    "build": "ts-node --compiler-options='{\"module\":\"commonJS\"}' src/index.ts build",
+    "build": "ts-node src/index.ts build",
     "lint": "eslint .",
     "release": "np",
     "test": "node script/test.js"

--- a/script/test.js
+++ b/script/test.js
@@ -1,6 +1,6 @@
-import chalk from 'chalk';
-import execa from 'execa';
-import Listr from 'listr';
+const chalk = require('chalk');
+const execa = require('execa');
+const Listr = require('listr');
 
 const tasks = new Listr([
 	{
@@ -31,10 +31,6 @@ const tasks = new Listr([
 	},
 ]);
 
-interface BuildError {
-	stdout: string;
-}
-
 tasks
 	.run()
 	.then(() =>
@@ -44,11 +40,11 @@ tasks
 			),
 		),
 	)
-	.catch((e: BuildError) => {
+	.catch((e) => {
 		console.log(
 			chalk.red(
 				'The builds are not identical. The project does not build itself correctly.',
 			),
-		);
-		console.log(e.stdout);
+		),
+			console.log(e.stdout);
 	});

--- a/src/verify-package-json.ts
+++ b/src/verify-package-json.ts
@@ -16,9 +16,9 @@ export const verifyPackageJson = () => {
 		);
 	}
 
-	pkg.main = 'dist/cjs/src/index.js';
-	pkg.module = 'dist/esm/src/index.js';
-	pkg.types = 'dist/types/src/index.d.ts';
+	pkg.main = 'dist/cjs/index.js';
+	pkg.module = 'dist/esm/index.js';
+	pkg.types = 'dist/types/index.d.ts';
 	pkg.files = ['dist', ...(pkg.files ?? [])];
 
 	// @ts-expect-error -- shouldn't be there

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -6,10 +6,10 @@
     "module": "ESNext",
     "moduleResolution": "node",
     "noEmit": true,
+    "rootDir": "src",
     "strict": true,
     "target": "ES2020"
   },
-  "include": ["src", "script"],
-  "exclude": ["node_modules", "dist", "coverage"],
-  "ts-node": { "compilerOptions": { "module": "commonjs" } }
+  "include": ["src"],
+  "exclude": ["node_modules", "dist", "coverage"]
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -11,5 +11,6 @@
     "target": "ES2020"
   },
   "include": ["src"],
-  "exclude": ["node_modules", "dist", "coverage"]
+  "exclude": ["node_modules", "dist", "coverage"],
+  "ts-node": { "compilerOptions": { "module": "commonjs" } }
 }


### PR DESCRIPTION
this change added the `script` dir to the dist output, by adding it to the tsconfig. this makes path in dist invalid in consumers that don’t do this (there’s not `src` dir) and breaks it.

it does show though how brittle this package is. i have a half a branch going that moves to rollup, and that's probably safer. 

but maybe it's possible to configure a third party instead to achieve the aims.

i also wonder whether finishing a monorepo for packages is a better thing to do. then the option is follow the guidelines yourself, or paved path monorepo...

for now, this just undoes that change though :)